### PR TITLE
Feat/start date endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,17 @@ variables.
 ## Usage
 
 ```
-usage: project_usage_exporter.py [-h] [-d DUMMY_DATA]
+usage: project_usage_exporter.py [-h] [-d DUMMY_DATA] [-w DUMMY_WEIGHTS]
                                  [--domain [DOMAIN [DOMAIN ...]]]
-                                 [--domain-id DOMAIN_ID] [-s START]
-                                 [-i UPDATE_INTERVAL] [-p PORT]
+                                 [--domain-id DOMAIN_ID]
+                                 [--vcpu-weights VCPU_WEIGHTS]
+                                 [--mb-weights MB_WEIGHTS]
+                                 [--simple-vm-id SIMPLE_VM_ID]
+                                 [--simple-vm-tag SIMPLE_VM_TAG]
+                                 [--weight-update-frequency WEIGHT_UPDATE_FREQUENCY]
+                                 [--weight-update-endpoint WEIGHT_UPDATE_ENDPOINT]
+                                 [--start-date-endpoint START_DATE_ENDPOINT]
+                                 [-s START] [-i UPDATE_INTERVAL] [-p PORT]
 
 Query project usages from an openstack instance and provide it in a prometheus
 compatible format. Alternatively develop in local mode and emulate machines
@@ -103,11 +110,16 @@ optional arguments:
                         updated . Defaults to the value of environment
                         variable $USAGE_EXPORTER_WEIGHTS_UPDATE_ENDPOINT or
                         will be left blank (default: )
+  --start-date-endpoint START_DATE_ENDPOINT
+                        The endpoint url where the start date can be updated .
+                        Defaults to the value of environment variable
+                        $USAGE_EXPORTER_START_DATE_ENDPOINT or will be left
+                        blank (default: None)
   -s START, --start START
                         Beginning time of stats (YYYY-MM-DD). If set the value
                         of environment variable $USAGE_EXPORTER_START_DATE is
-                        used. Uses maya for parsing. (default: 2020-07-21
-                        14:24:34.159480)
+                        used. Uses maya for parsing. (default: 2020-08-20
+                        23:01:54.732675)
   -i UPDATE_INTERVAL, --update-interval UPDATE_INTERVAL
                         Time to sleep between intervals, in case the calls
                         cause to much load on your openstack instance.

--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ optional arguments:
   -s START, --start START
                         Beginning time of stats (YYYY-MM-DD). If set the value
                         of environment variable $USAGE_EXPORTER_START_DATE is
-                        used. Uses maya for parsing. (default: 2020-08-20
-                        23:01:54.732675)
+                        used. Uses maya for parsing. (default: datetime.today())
   -i UPDATE_INTERVAL, --update-interval UPDATE_INTERVAL
                         Time to sleep between intervals, in case the calls
                         cause to much load on your openstack instance.

--- a/README.md
+++ b/README.md
@@ -111,8 +111,10 @@ optional arguments:
                         variable $USAGE_EXPORTER_WEIGHTS_UPDATE_ENDPOINT or
                         will be left blank (default: )
   --start-date-endpoint START_DATE_ENDPOINT
-                        The endpoint url where the start date can be updated .
-                        Defaults to the value of environment variable
+                        The endpoint url where the start date can be
+                        requested. If defined, requested date takes precedence
+                        over all other start date arguments. Defaults to the
+                        value of environment variable
                         $USAGE_EXPORTER_START_DATE_ENDPOINT or will be left
                         blank (default: None)
   -s START, --start START

--- a/project_usage_exporter.py
+++ b/project_usage_exporter.py
@@ -66,6 +66,7 @@ simple_vm_project_id_env_var = "USAGE_EXPORTER_SIMPLE_VM_PROJECT_ID"
 simple_vm_project_name_tag_env_var = "USAGE_EXPORTER_SIMPLE_VM_PROJECT_TAG"
 vcpu_weights_env_var = "USAGE_EXPORTER_VCPU_WEIGHTS"
 project_mb_weights_env_var = "USAGE_EXPORTER_PROJECT_MB_WEIGHTS"
+start_date_endpoint_env_var = "USAGE_EXPORTER_START_DATE_ENDPOINT"
 
 # name of the domain whose projects to monitor
 project_domain_env_var = "USAGE_EXPORTER_PROJECT_DOMAINS"
@@ -417,6 +418,13 @@ def main():
         . Defaults to the value of environment variable ${weights_update_endpoint_env_var} or will be left blank""",
     )
     parser.add_argument(
+        "--start-date-endpoint",
+        type=str,
+        default=getenv(start_date_endpoint_env_var, None),
+        help=f"""The endpoint url where the start date can be updated
+        . Defaults to the value of environment variable ${start_date_endpoint_env_var} or will be left blank""",
+    )
+    parser.add_argument(
         "-s",
         "--start",
         type=valid_date,
@@ -437,6 +445,15 @@ def main():
         "-p", "--port", type=int, default=8080, help="Port to provide metrics on"
     )
     args = parser.parse_args()
+    if args.start_date_endpoint:
+        try:
+            start_date_response = requests.get(args.start_date_endpoint)
+            start_date_response = start_date_response.json()
+            args.start = maya.when(start_date_response[0]["start_date"]).datetime()
+        except Exception as e:
+            logging.exception(f"Exception when getting start date from endpoint. Exception message: {e}. "
+                              f"Traceback following:\n")
+            return 1
     if args.dummy_data:
         logging.info("Using dummy export with data from %s", args.dummy_data.name)
         try:

--- a/project_usage_exporter.py
+++ b/project_usage_exporter.py
@@ -421,8 +421,9 @@ def main():
         "--start-date-endpoint",
         type=str,
         default=getenv(start_date_endpoint_env_var, None),
-        help=f"""The endpoint url where the start date can be updated
-        . Defaults to the value of environment variable ${start_date_endpoint_env_var} or will be left blank""",
+        help=f"""The endpoint url where the start date can be requested.
+        If defined, requested date takes precedence over all other start date arguments.
+        Defaults to the value of environment variable ${start_date_endpoint_env_var} or will be left blank""",
     )
     parser.add_argument(
         "-s",


### PR DESCRIPTION
@dweinholz 
Added --start-date-endpoint URL as option. Grabs start date from public api endpoint, which you need to add in /admin/ first!
Test with: ./project_usage_exporter.py -d resources/dummy_cc.toml --start-date-endpoint http://localhost:8000/public/startdate/

needs: https://github.com/deNBI/cloud-api/pull/1836